### PR TITLE
Update manifast to version 3

### DIFF
--- a/content.js
+++ b/content.js
@@ -8,7 +8,7 @@ chrome.runtime.onMessage.addListener(msg => {
     run();
 });
 
-export function run() {
+function run() {
     document.addEventListener("dblclick", e => {
         const text = window.getSelection().toString().trim();
         const specialCharOrEmpty = /(?:\W|^$)/.test(text);

--- a/manifest.json
+++ b/manifest.json
@@ -2,10 +2,10 @@
   "name": "double-click highlighter",
   "version": "1.1.2",
   "description": "Highlight a word by double click! This only works in github.com",
-  "manifest_version": 2,
+  "manifest_version": 3,
   "background": {
-    "scripts": ["background.js"],
-    "persistent": false
+    "service_worker": "background.js",
+    "type": "module"
   },
   "content_scripts": [
     {


### PR DESCRIPTION
## Changes
- Update manifast to version 3
  - https://developer.chrome.com/docs/extensions/migrating/to-service-workers/#update-bg-field
- Remove unnecessary export statements (causing errors when loading Chrome)
